### PR TITLE
Correct the links to the vendor's repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ This version is based on Android 9.0.0 [Release 30 (PQ1A.190105.004)](https://an
 ## There are added the follow new projects:
 | Location | Repo Link | Branch |
 | ------ | ------ |  ------ |
-| vendor/allwinner | [repo](https://github.com/android2orangepi-dev/android_sunxi_vendor) | master |
+| vendor/allwinner | [repo](https://github.com/android2orangepi-dev/android_allwinner_vendor) | master |
 | vendor/allwinner/external | [repo](https://github.com/android2orangepi-dev/u-boot_mainline_fork) | android-allwinner |
-| device/allwinner | [repo](https://github.com/android2orangepi-dev/android_sunxi_bsp) | master |
-| hardware/allwinner | [repo](https://github.com/android2orangepi-dev/android_sunxi_hardware) | master |
+| device/allwinner | [repo](https://github.com/android2orangepi-dev/android_allwinner_bsp) | master |
+| hardware/allwinner | [repo](https://github.com/android2orangepi-dev/android_allwinner_hardware) | master |
 | kernel/allwinner | [repo](https://github.com/android2orangepi-dev/linux) | android-allwinner |
  
 ## Fetching Android sources


### PR DESCRIPTION
The name of all vendor's repos were changed from 'sunxi' to 'allwinner'.