### PR TITLE
Rework Android folders struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,9 @@ This version is based on Android 9.0.0 [Release 30 (PQ1A.190105.004)](https://an
 | Location | Repo Link | Branch |
 | ------ | ------ | ------ |
 | vendor/allwinner | [repo](https://github.com/android2orangepi-dev/android_allwinner_vendor) | master |
-| vendor/u-boot | [repo](https://github.com/android2orangepi-dev/u-boot_mainline_fork) | android-allwinner |
-| vendor/tools | [repo](https://github.com/android2orangepi-dev/tools) | master |
+| external/uboot | [repo](http://git.denx.de/u-boot.git_mainline) | v2019.07-rc4 |
 | device/allwinner | [repo](https://github.com/android2orangepi-dev/android_allwinner_bsp) | master |
-| hardware/allwinner | [repo](https://github.com/android2orangepi-dev/android_allwinner_hardware) | master |
-| kernel/allwinner | [repo](https://github.com/android2orangepi-dev/linux) | android-allwinner |
+| kernel/allwinner | [repo](https://android.googlesource.com/kernel/common) | refs/heads/android-4.19 |
 | prebuilts/gcc/linux-x86/arm/gcc-linaro_arm-linux-gnueabihf | [repo](https://github.com/android2orangepi-dev/ext-compiler) | master |
  
 ## Fetching Android sources

--- a/allwinner.xml
+++ b/allwinner.xml
@@ -5,9 +5,11 @@
            fetch="https://android.googlesource.com/"
            review="https://android-review.googlesource.com/" />
 
-  <project path="kernel/allwinner" remote="google" name="kernel/common" revision="refs/heads/android-4.19" />
+  <remote  name="denx"
+           fetch="git://git.denx.de/" />
 
-  <project path="vendor/u-boot"      remote="devel-opi" name="u-boot_mainline_fork" revision="android-allwinner" />
+  <project path="kernel/allwinner" remote="google" name="kernel/common" revision="refs/heads/android-4.19" />
+  <project path="external/uboot"   remote="denx" name="u-boot.git" revision="v2019.07-rc4" />
 
   <project path="device/allwinner"   remote="devel-opi" name="android_allwinner_bsp"      revision="master" >
     <copyfile src="kernel/orangepi_plus2e_defconfig" dest="kernel/allwinner/arch/arm/configs/orangepi_plus2e_defconfig" />

--- a/allwinner.xml
+++ b/allwinner.xml
@@ -5,18 +5,17 @@
            fetch="https://android.googlesource.com/"
            review="https://android-review.googlesource.com/" />
 
-  <remote  name="denx"
-           fetch="git://git.denx.de/" />
+  <remote  name="denx.de"
+           fetch="http://git.denx.de/" />
 
-  <project path="kernel/allwinner" remote="google" name="kernel/common" revision="refs/heads/android-4.19" />
-  <project path="external/uboot"   remote="denx" name="u-boot.git" revision="v2019.07-rc4" />
-
-  <project path="device/allwinner"   remote="devel-opi" name="android_allwinner_bsp"      revision="master" >
+  <project path="external/uboot"    remote="denx.de"   name="u-boot.git"               revision="refs/tags/v2019.07-rc4" />
+  <project path="kernel/allwinner"  remote="google"    name="kernel/common"            revision="refs/heads/android-4.19" />
+  <project path="vendor/allwinner"  remote="devel-opi" name="android_allwinner_vendor" revision="master" />
+  <project path="device/allwinner"  remote="devel-opi" name="android_allwinner_bsp"    revision="master" >
     <copyfile src="kernel/orangepi_plus2e_defconfig" dest="kernel/allwinner/arch/arm/configs/orangepi_plus2e_defconfig" />
     <copyfile src="kernel/sunxi.dtbimg.cfg"          dest="kernel/allwinner/arch/arm/boot/dts/sunxi.dtbimg.cfg" />
   </project>
-
-  <project path="vendor/allwinner"   remote="devel-opi" name="android_allwinner_vendor"   revision="master" />
+ 
   <project path="prebuilts/gcc/linux-x86/arm/gcc-linaro_arm-linux-gnueabihf" remote="devel-opi" name="ext-compiler" revision="master" />
 
 </manifest>

--- a/allwinner.xml
+++ b/allwinner.xml
@@ -15,7 +15,6 @@
   </project>
 
   <project path="vendor/allwinner"   remote="devel-opi" name="android_allwinner_vendor"   revision="master" />
-  <project path="hardware/allwinner" remote="devel-opi" name="android_allwinner_hardware" revision="master" />
   <project path="prebuilts/gcc/linux-x86/arm/gcc-linaro_arm-linux-gnueabihf" remote="devel-opi" name="ext-compiler" revision="master" />
 
   <!-- Copying files from project "kernel/configs" of "google" -->

--- a/allwinner.xml
+++ b/allwinner.xml
@@ -8,18 +8,15 @@
   <project path="kernel/allwinner" remote="google" name="kernel/common" revision="refs/heads/android-4.19" />
 
   <project path="vendor/u-boot"      remote="devel-opi" name="u-boot_mainline_fork" revision="android-allwinner" />
-  <project path="device/allwinner"   remote="devel-opi" name="android_allwinner_bsp"      revision="master" />
-  <project path="vendor/allwinner"   remote="devel-opi" name="android_allwinner_vendor"   revision="master" />
-  <project path="hardware/allwinner" remote="devel-opi" name="android_allwinner_hardware" revision="master" />
 
-  <project path="prebuilts/gcc/linux-x86/arm/gcc-linaro_arm-linux-gnueabihf" remote="devel-opi" name="ext-compiler" revision="master" />
-
-  <project path="vendor/tools" remote="devel-opi" name="tools" revision="master" >
-    <copyfile src="kernel/kernel.mk"                 dest="kernel/allwinner/Android.mk" />
-    <copyfile src="kernel/sunxi_defconfig"           dest="kernel/allwinner/arch/arm/configs/sunxi_defconfig" />
+  <project path="device/allwinner"   remote="devel-opi" name="android_allwinner_bsp"      revision="master" >
     <copyfile src="kernel/orangepi_plus2e_defconfig" dest="kernel/allwinner/arch/arm/configs/orangepi_plus2e_defconfig" />
     <copyfile src="kernel/sunxi.dtbimg.cfg"          dest="kernel/allwinner/arch/arm/boot/dts/sunxi.dtbimg.cfg" />
   </project>
+
+  <project path="vendor/allwinner"   remote="devel-opi" name="android_allwinner_vendor"   revision="master" />
+  <project path="hardware/allwinner" remote="devel-opi" name="android_allwinner_hardware" revision="master" />
+  <project path="prebuilts/gcc/linux-x86/arm/gcc-linaro_arm-linux-gnueabihf" remote="devel-opi" name="ext-compiler" revision="master" />
 
   <!-- Copying files from project "kernel/configs" of "google" -->
   <copyfile src="kernel/configs/p/android-4.14/android-base.cfg"        dest="kernel/allwinner/arch/arm/config/android-base.cfg" />

--- a/allwinner.xml
+++ b/allwinner.xml
@@ -19,8 +19,4 @@
   <project path="vendor/allwinner"   remote="devel-opi" name="android_allwinner_vendor"   revision="master" />
   <project path="prebuilts/gcc/linux-x86/arm/gcc-linaro_arm-linux-gnueabihf" remote="devel-opi" name="ext-compiler" revision="master" />
 
-  <!-- Copying files from project "kernel/configs" of "google" -->
-  <copyfile src="kernel/configs/p/android-4.14/android-base.cfg"        dest="kernel/allwinner/arch/arm/config/android-base.cfg" />
-  <copyfile src="kernel/configs/p/android-4.14/android-recommended.cfg" dest="kernel/allwinner/arch/arm/config/android-recommended.cfg" />
-
 </manifest>


### PR DESCRIPTION
There we changed a structure of Android project folders:
- move tool repo to bsp
- fetch u-boot from mainline (custom fork is not used)
- remove hardware repo from fetching as unused