### PR TITLE
Add additional packages for building under Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This version is based on [Android 10.0.0 Release 5](https://android.googlesource
 For Android build you need to set up your local work environment according [Google's recommendations](https://source.android.com/setup/build/initializing). Probably You need to install additional packets.
 
 ```bash
-sudo apt-get install swig lz4 repo python-dev python3-dev libssl-dev
+sudo apt-get install swig lz4 repo python-dev python3-dev libssl-dev flex bison
 pip install Mako
 ```
  


### PR DESCRIPTION
Add additional packages (flex and bison) for building under Ubuntu.

Without these packages, the build for Ubuntu 18.04 fails:
`GEN     ./Makefile
  YACC    scripts/kconfig/zconf.tab.c
/bin/sh: 1: bison: not found
scripts/Makefile.lib:226: recipe for target 'scripts/kconfig/zconf.tab.c' failed
make[2]: *** [scripts/kconfig/zconf.tab.c] Error 127
make[2]: *** Waiting for unfinished jobs....
  LEX     scripts/kconfig/zconf.lex.c
/bin/sh: 1: flex: not found`