### PR TITLE
Update TV application 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This version is based on [Android 10.0.0 Release 5](https://android.googlesource
 For Android build you need to set up your local work environment according [Google's recommendations](https://source.android.com/setup/build/initializing). Probably You need to install additional packets.
 
 ```bash
-sudo apt-get install swig lz4 repo python-dev python3-dev libssl-dev
+sudo apt-get install swig lz4 repo python-dev python3-dev libssl-dev flex bison
 pip install Mako
 ```
  

--- a/allwinner.xml
+++ b/allwinner.xml
@@ -28,4 +28,7 @@
   <project path="kernel/allwinner-modules/rtl8189ES_linux" remote="github" name="rsglobal/rtl8189ES_linux" revision="fix-ap-crash-pr" />
   <project path="external/tinyhal" remote="github" name="CirrusLogic/tinyhal" revision="3c3e49e2383004b9115216048320f9648db3b360" />
 
+  <remove-project name="platform/packages/apps/TV" />
+  <project path="packages/apps/TV" name="platform/packages/apps/TV" remote="aosp" revision="3399fc08dec05bdaf6a9f3898951c290a4e724dc" />
+
 </manifest>


### PR DESCRIPTION
Update the TV application to support Android TV for Android Q, as the old version of the TV application uses deprecated Java collections.